### PR TITLE
Make random_state descriptions more informative and refer to Glossary for sklearn/preprocessing/_data.py towards #10548

### DIFF
--- a/sklearn/preprocessing/_data.py
+++ b/sklearn/preprocessing/_data.py
@@ -2176,7 +2176,7 @@ class QuantileTransformer(TransformerMixin, BaseEstimator):
         differ for value-identical sparse and dense matrices.
 
     random_state : int, RandomState instance or None, optional (default=None)
-        Determines random number generation for subsampling.
+        Determines random number generation for subsampling and smoothing noise.
         Please see ``subsample`` for more details.
         Pass an int for reproducible results across multiple function calls.
         See :term:`Glossary <random_state>`
@@ -2604,7 +2604,7 @@ def quantile_transform(X, axis=0, n_quantiles=1000,
         differ for value-identical sparse and dense matrices.
 
     random_state : int, RandomState instance or None, optional (default=None)
-        Determines random number generation for subsampling.
+        Determines random number generation for subsampling and smoothing noise.
         Please see ``subsample`` for more details.
         Pass an int for reproducible results across multiple function calls.
         See :term:`Glossary <random_state>`

--- a/sklearn/preprocessing/_data.py
+++ b/sklearn/preprocessing/_data.py
@@ -2179,7 +2179,7 @@ class QuantileTransformer(TransformerMixin, BaseEstimator):
         Determines random number generation for subsampling.
         Please see ``subsample`` for more details.
         Pass an int for reproducible results across multiple function calls.
-        See :term:`Glossary <random_state>, <subsample>`
+        See :term:`Glossary <random_state>`
 
     copy : boolean, optional, (default=True)
         Set to False to perform inplace transformation and avoid a copy (if the
@@ -2607,7 +2607,7 @@ def quantile_transform(X, axis=0, n_quantiles=1000,
         Determines random number generation for subsampling.
         Please see ``subsample`` for more details.
         Pass an int for reproducible results across multiple function calls.
-        See :term:`Glossary <random_state>, <subsample>`
+        See :term:`Glossary <random_state>`
 
     copy : boolean, optional, (default=True)
         Set to False to perform inplace transformation and avoid a copy (if the

--- a/sklearn/preprocessing/_data.py
+++ b/sklearn/preprocessing/_data.py
@@ -2176,11 +2176,10 @@ class QuantileTransformer(TransformerMixin, BaseEstimator):
         differ for value-identical sparse and dense matrices.
 
     random_state : int, RandomState instance or None, optional (default=None)
-        If int, random_state is the seed used by the random number generator;
-        If RandomState instance, random_state is the random number generator;
-        If None, the random number generator is the RandomState instance used
-        by np.random. Note that this is used by subsampling and smoothing
-        noise.
+        Determines random number generation for subsampling.
+        Please see ``subsample`` for more details.
+        Pass an int for reproducible results across multiple function calls.
+        See :term:`Glossary <random_state>, <subsample>`
 
     copy : boolean, optional, (default=True)
         Set to False to perform inplace transformation and avoid a copy (if the
@@ -2605,11 +2604,10 @@ def quantile_transform(X, axis=0, n_quantiles=1000,
         differ for value-identical sparse and dense matrices.
 
     random_state : int, RandomState instance or None, optional (default=None)
-        If int, random_state is the seed used by the random number generator;
-        If RandomState instance, random_state is the random number generator;
-        If None, the random number generator is the RandomState instance used
-        by np.random. Note that this is used by subsampling and smoothing
-        noise.
+        Determines random number generation for subsampling.
+        Please see ``subsample`` for more details.
+        Pass an int for reproducible results across multiple function calls.
+        See :term:`Glossary <random_state>, <subsample>`
 
     copy : boolean, optional, (default=True)
         Set to False to perform inplace transformation and avoid a copy (if the

--- a/sklearn/preprocessing/_data.py
+++ b/sklearn/preprocessing/_data.py
@@ -2176,7 +2176,7 @@ class QuantileTransformer(TransformerMixin, BaseEstimator):
         differ for value-identical sparse and dense matrices.
 
     random_state : int, RandomState instance or None, optional (default=None)
-        Determines random number generation for subsampling and smoothing 
+        Determines random number generation for subsampling and smoothing
         noise.
         Please see ``subsample`` for more details.
         Pass an int for reproducible results across multiple function calls.
@@ -2605,7 +2605,7 @@ def quantile_transform(X, axis=0, n_quantiles=1000,
         differ for value-identical sparse and dense matrices.
 
     random_state : int, RandomState instance or None, optional (default=None)
-        Determines random number generation for subsampling and smoothing 
+        Determines random number generation for subsampling and smoothing
         noise.
         Please see ``subsample`` for more details.
         Pass an int for reproducible results across multiple function calls.

--- a/sklearn/preprocessing/_data.py
+++ b/sklearn/preprocessing/_data.py
@@ -2176,7 +2176,8 @@ class QuantileTransformer(TransformerMixin, BaseEstimator):
         differ for value-identical sparse and dense matrices.
 
     random_state : int, RandomState instance or None, optional (default=None)
-        Determines random number generation for subsampling and smoothing noise.
+        Determines random number generation for subsampling and smoothing 
+        noise.
         Please see ``subsample`` for more details.
         Pass an int for reproducible results across multiple function calls.
         See :term:`Glossary <random_state>`
@@ -2604,7 +2605,8 @@ def quantile_transform(X, axis=0, n_quantiles=1000,
         differ for value-identical sparse and dense matrices.
 
     random_state : int, RandomState instance or None, optional (default=None)
-        Determines random number generation for subsampling and smoothing noise.
+        Determines random number generation for subsampling and smoothing 
+        noise.
         Please see ``subsample`` for more details.
         Pass an int for reproducible results across multiple function calls.
         See :term:`Glossary <random_state>`


### PR DESCRIPTION
Reference Issue/PR:
#10548

We (@rachelcjordan, @fabi-cast and me) updated the documentation for random_state in 'sklearn/preprocessing/_data.py - 2178, 2607'. It now refers to the glossary.

Partial fix for issue #10548.

@noatamir
@adrinjalali
@WiMLDS